### PR TITLE
Add 10 second delay after agent init

### DIFF
--- a/main.php
+++ b/main.php
@@ -15,6 +15,9 @@ $dotenv->load(__DIR__ . '/.env');
 
 $client = HttpClient::create();
 
+echo("-- Waiting for initialization --\n");
+sleep(10);
+
 
 // Postman Echo
 


### PR DESCRIPTION
Environments are created asynchronously on the back-end. We must wait for that to happen so that all built-in rules have been created and sent to the agent.

This is a temporary measure until we fix this properly.